### PR TITLE
fix(licenses): apply oss-licenses-plugin to fix OssLicensesActivity NPE

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,6 +28,7 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.gms)
     alias(libs.plugins.firebase.crashlytics)
+    alias(libs.plugins.google.oss.licenses)
     alias(libs.plugins.dokka)
 }
 

--- a/app/src/main/kotlin/dev/atick/shorts/ui/screens/MainScreen.kt
+++ b/app/src/main/kotlin/dev/atick/shorts/ui/screens/MainScreen.kt
@@ -18,6 +18,7 @@ package dev.atick.shorts.ui.screens
 
 import android.content.Intent
 import android.net.Uri
+import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -562,12 +563,21 @@ private fun FooterSection(
             FooterLink(
                 text = "Licenses",
                 onClick = {
-                    context.startActivity(
-                        Intent(
+                    try {
+                        context.startActivity(
+                            Intent(
+                                context,
+                                OssLicensesMenuActivity::class.java,
+                            ),
+                        )
+                    } catch (e: Exception) {
+                        Timber.e(e, "Failed to open OSS licenses screen")
+                        Toast.makeText(
                             context,
-                            OssLicensesMenuActivity::class.java,
-                        ),
-                    )
+                            "Unable to open licenses",
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                    }
                 },
             )
 


### PR DESCRIPTION
## Summary
- Applies `com.google.android.gms.oss-licenses-plugin` in `app/build.gradle.kts` — it was declared `apply false` at the root but never actually applied, so the `res/raw/third_party_licenses*` resources `OssLicensesActivity` reads at runtime were never generated, causing a fatal NPE on launch.
- Wraps the "Licenses" footer link's `startActivity` call in a try/catch (with a `Toast` fallback) as defense in depth, so any future resource/config regression degrades gracefully instead of crashing.

Fixes #79

## Test plan
- [x] `./gradlew :app:assembleDebug` and `./gradlew :app:assembleRelease` succeed
- [x] Confirmed `app/build/generated/res/releaseOssLicensesTask/raw/third_party_license*` are generated with real dependency data (~300KB) in the release variant
- [x] `./gradlew :app:testDebugUnitTest` passes
- [x] Manually verified on emulators at API 24 (minSdk), API 30, and API 36 (targetSdk) using the release build: tapped "Licenses" in the footer, confirmed `OssLicensesMenuActivity` opens and renders the dependency list with no crash (logcat clean of FATAL/AndroidRuntime crash entries on all three)

🤖 Generated with [Claude Code](https://claude.com/claude-code)