### PR TITLE
feat: add debug logging for accessibility detection (#76)

### DIFF
--- a/app/src/main/kotlin/dev/atick/shorts/services/ShortFormContentBlockerService.kt
+++ b/app/src/main/kotlin/dev/atick/shorts/services/ShortFormContentBlockerService.kt
@@ -133,6 +133,12 @@ class ShortFormContentBlockerService : AccessibilityService() {
         Timber.w("ShortFormContentBlockerService interrupted")
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        Timber.d("ShortFormContentBlockerService destroyed")
+        job.cancel()
+    }
+
     /**
      * Handles detection of short-form content by performing a back navigation action.
      *

--- a/app/src/main/kotlin/dev/atick/shorts/services/detectors/InstagramReelsDetector.kt
+++ b/app/src/main/kotlin/dev/atick/shorts/services/detectors/InstagramReelsDetector.kt
@@ -93,6 +93,7 @@ class InstagramReelsDetector : ShortFormContentDetector {
             Timber.i("[Instagram] ✓ User is actively watching Media in Fullscreen")
             return true
         }
+        Timber.v("[Instagram] No Reels detected ($nodesScanned nodes scanned, feedTabCount=$feedTabCount)")
         return false
     }
 }

--- a/app/src/main/kotlin/dev/atick/shorts/services/detectors/YouTubeShortsDetector.kt
+++ b/app/src/main/kotlin/dev/atick/shorts/services/detectors/YouTubeShortsDetector.kt
@@ -73,6 +73,7 @@ class YouTubeShortsDetector : ShortFormContentDetector {
             }
         }
 
+        Timber.v("[YouTube] No Shorts detected ($nodeCount nodes scanned)")
         return false
     }
 }


### PR DESCRIPTION
Adds Timber.v logs on the negative detection path in YouTubeShortsDetector and InstagramReelsDetector, and onDestroy() lifecycle log to ShortFormContentBlockerService.

Before this change, when the service was running but nothing was being blocked, there was no way to tell from a logcat whether the detector evaluated and found nothing, or if the service wasn't receiving events at all.

This adds verbose logs on the negative detection path in both detectors, and a lifecycle log when the service is destroyed — all gated behind Timber so nothing leaks in release builds.

Testing: install debug build, enable the service, open YouTube feed → [YouTube] No Shorts detected should appear in Logcat. Open a Short → back action fires normally. Disable the service → ShortFormContentBlockerService destroyed.

Closes #76